### PR TITLE
chore: add Taskfile and deprecate Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,29 @@
+# DEPRECATED: This Makefile is deprecated in favour of Taskfile.yml (https://taskfile.dev).
+# Run `task --list-all` to see available tasks. The Makefile remains as a thin
+# wrapper for the transition period and will be removed in a future release.
+
+define DEPRECATION_BANNER
+
+
+╔══════════════════════════════════════════════════════════════════════╗
+║                                                                      ║
+║   WARNING: This Makefile is DEPRECATED.                              ║
+║                                                                      ║
+║   Use Taskfile (https://taskfile.dev) instead:                       ║
+║       task --list-all      # show available tasks                    ║
+║       task <task-name>     # run a task                              ║
+║                                                                      ║
+║   Install task:  brew install go-task                                ║
+║   This Makefile will be removed in a future release.                 ║
+║                                                                      ║
+╚══════════════════════════════════════════════════════════════════════╝
+
+
+endef
+export DEPRECATION_BANNER
+
+$(info $(DEPRECATION_BANNER))
+
 default: all
 
 all: mdbxv

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,17 @@
+# https://taskfile.dev
+version: '3'
+
+tasks:
+  default:
+    cmds:
+      - task: all
+
+  all:
+    desc: Build everything (mdbxv)
+    deps: [mdbxv]
+
+  mdbxv:
+    desc: Build the MDBX Viewer image and bring up the stack
+    cmds:
+      - echo "Building MDBX Viewer..."
+      - docker compose up -d --build --force-recreate


### PR DESCRIPTION
## Summary
- Add `Taskfile.yml` (https://taskfile.dev) mirroring the existing Make targets.
- Mark the Makefile as deprecated (header comment + loud banner printed on every invocation).
- Old `make` invocations still work for now; new canonical entry points are `task` / `task mdbxv`.

## Test plan
- [x] `task --list-all` shows the available tasks
- [x] `make -n` prints the deprecation banner
- [ ] Reviewer: `task mdbxv` brings up the stack on a fresh checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)